### PR TITLE
HSV入力のカラーピッカーの実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,13 @@
         <input type="button" id="$random" value="ランダム">
       </fieldset>
     </form>
+    <form name="colorpicker" id="$colorpicker">
+      <output name="rgb"></output>
+      <div class="palette"><div class="thumb"></div></div>
+      <output name="saturation"></output>
+      <output name="brightness"></output>
+      <input type="range" name="hue" min="0" max="360">
+    </form>
     <form name="viewbox" id="$viewbox">
       <h4>ViewBox</h4>
       <label>サイズ: <span></span>
@@ -144,4 +151,46 @@
     </p>
   </small>
 </footer>
+<style>
+  [id="$colorpicker"] {
+    --thumb-size: 24px;
+    .palette {
+      margin: var(--thumb-size);
+      position: relative;
+      width: 200px;
+      height: 200px;
+      background-color: hsl(var(--picked-hue, 0) 100% 50%);
+      background-image:
+        linear-gradient(to top, #000, #0000),
+        linear-gradient(to left, #fff0, #fff);
+    }
+    .thumb {
+      position: absolute;
+      width: var(--thumb-size);
+      height: var(--thumb-size);
+      border: solid 2px #fff;
+      border-radius: 12px;
+      background: transparent;
+      transform: translate(
+        calc(var(--thumb-size) * -0.5),
+        calc(var(--thumb-size) * -0.5)
+      );
+    }
+    [name="hue"] {
+      --pico-range-border-color: transparent;
+      --pico-range-thumb-color: transparent;
+      --pico-range-thumb-active-color: transparent;
+      background: linear-gradient(
+        to right,
+        hsl(0deg 100% 50%),
+        hsl(60deg 100% 50%),
+        hsl(120deg 100% 50%),
+        hsl(180deg 100% 50%),
+        hsl(240deg 100% 50%),
+        hsl(300deg 100% 50%),
+        hsl(360deg 100% 50%)
+      );
+    }
+  }
+</style>
 <script type="module" src="./main.js"></script>

--- a/index.html
+++ b/index.html
@@ -44,6 +44,47 @@
   label:has(input:disabled) {
     display: none;
   }
+  input[type="range"] {
+    touch-action: pinch-zoom;
+  }
+  [id="$colorpicker"] {
+    --thumb-size: 24px;
+    [id="$colorpallet"] {
+      margin: 0 auto var(--thumb-size);
+      position: relative;
+      aspect-ratio: 2/1;
+      max-width: 400px;
+      background-color: hsl(var(--picked-hue, 0) 100% 50%);
+      background-image:
+        linear-gradient(to top, #000, #0000),
+        linear-gradient(to left, #fff0, #fff);
+      touch-action: pinch-zoom;
+    }
+    [id="$colorSV"] {
+      position: absolute;
+      width: var(--thumb-size);
+      height: var(--thumb-size);
+      border: solid 2px #fff;
+      border-radius: 12px;
+      background: transparent;
+      transform: translate(-50%, -50%);
+    }
+    [id="$colorH"] {
+      --pico-range-border-color: transparent;
+      --pico-range-thumb-color: transparent;
+      --pico-range-thumb-active-color: transparent;
+      background: linear-gradient(
+        to right,
+        hsl(0deg 100% 50%),
+        hsl(60deg 100% 50%),
+        hsl(120deg 100% 50%),
+        hsl(180deg 100% 50%),
+        hsl(240deg 100% 50%),
+        hsl(300deg 100% 50%),
+        hsl(360deg 100% 50%)
+      );
+    }
+  }
 </style>
 
 <header class="container">
@@ -82,6 +123,10 @@
     </form>
     <form name="color" id="$color">
       <h4>色</h4>
+      <fieldset role="group">
+        <input id="$reset" type="reset" value="デフォルトをセット">
+        <input type="button" id="$random" value="ランダム">
+      </fieldset>
       <label>
         <input type="checkbox" name="bgtransparent" role="switch">背景透明
       </label>
@@ -89,17 +134,10 @@
       <input type="color" name="bodycolor" value="#cccccc">
       <input type="color" name="strokecolor" value="#323232">
       <input type="color" name="hugecolor" value="#80ffa6">
-      <fieldset role="group">
-        <input id="$reset" type="reset" value="デフォルトに戻す">
-        <input type="button" id="$random" value="ランダム">
+      <fieldset name="colorpicker" id="$colorpicker">
+        <div id="$colorpallet"><div id="$colorSV"></div></div>
+        <input type="range" name="hue" min="0" max="360" id="$colorH">
       </fieldset>
-    </form>
-    <form name="colorpicker" id="$colorpicker">
-      <output name="rgb"></output>
-      <div class="palette"><div class="thumb"></div></div>
-      <output name="saturation"></output>
-      <output name="brightness"></output>
-      <input type="range" name="hue" min="0" max="360">
     </form>
     <form name="viewbox" id="$viewbox">
       <h4>ViewBox</h4>
@@ -151,46 +189,4 @@
     </p>
   </small>
 </footer>
-<style>
-  [id="$colorpicker"] {
-    --thumb-size: 24px;
-    .palette {
-      margin: var(--thumb-size);
-      position: relative;
-      width: 200px;
-      height: 200px;
-      background-color: hsl(var(--picked-hue, 0) 100% 50%);
-      background-image:
-        linear-gradient(to top, #000, #0000),
-        linear-gradient(to left, #fff0, #fff);
-    }
-    .thumb {
-      position: absolute;
-      width: var(--thumb-size);
-      height: var(--thumb-size);
-      border: solid 2px #fff;
-      border-radius: 12px;
-      background: transparent;
-      transform: translate(
-        calc(var(--thumb-size) * -0.5),
-        calc(var(--thumb-size) * -0.5)
-      );
-    }
-    [name="hue"] {
-      --pico-range-border-color: transparent;
-      --pico-range-thumb-color: transparent;
-      --pico-range-thumb-active-color: transparent;
-      background: linear-gradient(
-        to right,
-        hsl(0deg 100% 50%),
-        hsl(60deg 100% 50%),
-        hsl(120deg 100% 50%),
-        hsl(180deg 100% 50%),
-        hsl(240deg 100% 50%),
-        hsl(300deg 100% 50%),
-        hsl(360deg 100% 50%)
-      );
-    }
-  }
-</style>
 <script type="module" src="./main.js"></script>

--- a/main.js
+++ b/main.js
@@ -351,71 +351,66 @@ var draw2 = ({ parts: parts3 = [], color, viewbox, style }) => {
 var puge = { name: name2, parts: parts2, draw: draw2 };
 
 // src/colorpicker.ts
-var initColorPicker = (dom) => {
-  const $palette = dom.querySelector(".palette");
-  const $thumb = dom.querySelector(".thumb");
-  const $hue = dom.querySelector(`input[name="hue"]`);
-  const $saturation = dom.querySelector(
-    `[name="saturation"]`
-  );
-  const $brightness = dom.querySelector(
-    `[name="brightness"]`
-  );
-  if (!$palette || !$thumb || !$hue || !$saturation || !$brightness) {
-    throw new Error("dom is not ColorPicker");
-  }
-  let target;
-  const state = { h: 138, s: 0.5, v: 1 };
-  const setTarget = ($input) => {
+var target;
+var state = { h: 138, s: 0.5, v: 1 };
+var setPicker = ($input) => {
+  if ($input)
     target = $input;
-    setHSV(toHSV(target.value));
+  setHSV(toHSV(target.value));
+  target?.insertAdjacentElement("afterend", $colorpicker);
+};
+var setHSV = ({ h, s, v }, needsRGB = false) => {
+  if (h != void 0 && h != state.h) {
+    state.h = h;
+    $colorH.valueAsNumber = h;
+    $colorpicker.style.setProperty("--picked-hue", h.toString());
+    needsRGB = true;
+  }
+  if (s != void 0 && s != state.s) {
+    state.s = s;
+    $colorSV.style.setProperty("left", `${100 * s}%`);
+    needsRGB = true;
+  }
+  if (v != void 0 && v != state.v) {
+    state.v = v;
+    $colorSV.style.setProperty("top", `${100 - 100 * v}%`);
+    needsRGB = true;
+  }
+  if (target && needsRGB) {
+    target.value = toRGB(...Object.values(state));
+    target.dispatchEvent(
+      new InputEvent("input", { bubbles: true, cancelable: true })
+    );
+  }
+};
+var handlePointerMove = (e) => {
+  if (e.buttons == 1) {
+    $colorpallet.setPointerCapture(e.pointerId);
+    const { width, height } = $colorpallet.getBoundingClientRect();
+    const v = clamp(1 - e.offsetY / height, 0, 1);
+    const s = clamp(e.offsetX / width, 0, 1);
+    setHSV({ s, v });
+  }
+};
+var initColorPicker = (inputs, { initTarget = inputs.at(-1) } = {}) => {
+  $colorH.oninput = () => {
+    setHSV({ h: $colorH.valueAsNumber });
   };
-  const setHSV = ({ h, s, v }, needsRGB = false) => {
-    if (h != void 0 && h != state.h) {
-      state.h = h;
-      $hue.valueAsNumber = h;
-      dom.style.setProperty("--picked-hue", "" + h);
-      needsRGB = true;
-    }
-    if (s != void 0 && s != state.s) {
-      state.s = s;
-      $thumb.style.setProperty("left", `${100 * s}%`);
-      needsRGB = true;
-    }
-    if (v != void 0 && v != state.v) {
-      state.v = v;
-      $thumb.style.setProperty("top", `${100 - 100 * v}%`);
-      needsRGB = true;
-    }
-    if (target && needsRGB) {
-      target.value = toRGB(...Object.values(state));
-      target.dispatchEvent(
-        new InputEvent("input", { bubbles: true, cancelable: true })
-      );
-    }
-  };
-  const { width: paletteWidth, height: paletteHeight } = $palette.getBoundingClientRect();
-  $hue.oninput = () => {
-    setHSV({ h: $hue.valueAsNumber });
-  };
-  const handlePointerMove = (e) => {
-    if (e.buttons == 1) {
-      $palette.setPointerCapture(e.pointerId);
-      const top = clamp(e.offsetY, 0, paletteHeight);
-      const left = clamp(e.offsetX, 0, paletteWidth);
-      setHSV({ s: left / paletteWidth, v: 1 - top / paletteHeight });
-    }
-  };
-  $palette.onpointermove = handlePointerMove;
-  $palette.onpointerdown = handlePointerMove;
-  document.querySelectorAll(`input[type="color"]`).forEach(
-    ($input) => $input.addEventListener("click", (e) => {
-      if ($input.disabled || !$input.name)
+  $colorpallet.onpointermove = handlePointerMove;
+  $colorpallet.onpointerdown = handlePointerMove;
+  inputs.forEach(($input) => {
+    $input.addEventListener("click", (e) => {
+      if ($input == target || $input.disabled || !$input.name)
         return;
       e.preventDefault();
-      setTarget($input);
-    })
-  );
+      setPicker($input);
+    });
+    $input.addEventListener("input", () => {
+      if ($input == target)
+        setHSV(toHSV(target.value));
+    });
+  });
+  setPicker(initTarget);
 };
 
 // src/main.ts
@@ -454,10 +449,12 @@ $reset.onclick = (e) => {
   e.preventDefault();
   $color.reset();
   setColor();
+  setPicker();
 };
 $random.onclick = () => {
   $color.hugecolor.value = toRGB(Math.random() * 360);
   setColor();
+  setPicker();
 };
 var setViewbox = throttle(() => {
   $viewbox.querySelectorAll(`label:has([type="range"])`).forEach(($label) => {
@@ -517,4 +514,7 @@ $output.onsubmit = () => {
 setHuge();
 setViewbox();
 setSVG();
-initColorPicker($colorpicker);
+var $colorInputs = [...$color.elements].filter(isInput).filter(
+  (el) => el.type === "color"
+);
+initColorPicker($colorInputs);

--- a/main.js
+++ b/main.js
@@ -35,8 +35,8 @@ function getViewboxString(formdata, { svgSize = 512 } = {}) {
   const y = Math.round(cy - w / 2);
   return [x, y, w, w].join(" ");
 }
-var clamp = (n, min, max) => Math.min(max, Math.max(min, n));
-var toRGB = (h = 138, s = 0.5, v = 1) => {
+var clamp = (n, min = 0, max = 1) => Math.min(max, Math.max(min, n));
+var toRGB = ({ h = 360, s = 0.5, v = 1 } = {}) => {
   h = (h < 0 ? h % 360 + 360 : h) % 360 / 60;
   s = clamp(s, 0, 1);
   v = clamp(v, 0, 1);
@@ -47,7 +47,7 @@ var toRGB = (h = 138, s = 0.5, v = 1) => {
   );
   return `#${(r << 16 | g << 8 | b).toString(16).padStart(6, "0")}`;
 };
-var toHSV = (rgb = "#80ffa6") => {
+var toHSV = (rgb = "#ff8080") => {
   const rgbNum = parseInt(rgb.replaceAll(/[^a-f\d]/ig, ""), 16), [r, g, b] = [16, 8, 0].map((n) => rgbNum >> n & 255), max = Math.max(r, g, b), diff = max - Math.min(r, g, b), i = [r, g, b].indexOf(max), [a1, a2] = [r, g, b, r, g].slice(i + 1), v = max / 255, s = max ? diff / max : 0, h = s ? ((a1 - a2) / diff * 60 + 120 * i + 360) % 360 : 0;
   return { h, s, v };
 };
@@ -377,14 +377,14 @@ var setHSV = ({ h, s, v }, needsRGB = false) => {
     needsRGB = true;
   }
   if (target && needsRGB) {
-    target.value = toRGB(...Object.values(state));
+    target.value = toRGB(state);
     target.dispatchEvent(
       new InputEvent("input", { bubbles: true, cancelable: true })
     );
   }
 };
 var handlePointerMove = (e) => {
-  if (e.buttons == 1) {
+  if (e.target == e.currentTarget && e.buttons == 1) {
     $colorpallet.setPointerCapture(e.pointerId);
     const { width, height } = $colorpallet.getBoundingClientRect();
     const v = clamp(1 - e.offsetY / height, 0, 1);
@@ -452,7 +452,7 @@ $reset.onclick = (e) => {
   setPicker();
 };
 $random.onclick = () => {
-  $color.hugecolor.value = toRGB(Math.random() * 360);
+  $color.hugecolor.value = toRGB({ h: Math.random() * 360, s: 0.5, v: 1 });
   setColor();
   setPicker();
 };

--- a/src/colorpicker.ts
+++ b/src/colorpicker.ts
@@ -30,14 +30,14 @@ const setHSV = ({ h, s, v }: Partial<HSV>, needsRGB = false) => {
     needsRGB = true;
   }
   if (target && needsRGB) {
-    target.value = toRGB(...Object.values(state));
+    target.value = toRGB(state);
     target.dispatchEvent(
       new InputEvent("input", { bubbles: true, cancelable: true }),
     );
   }
 };
 const handlePointerMove = (e: PointerEvent) => {
-  if (e.buttons == 1) {
+  if (e.target == e.currentTarget && e.buttons == 1) {
     $colorpallet.setPointerCapture(e.pointerId);
     const { width, height } = $colorpallet.getBoundingClientRect();
     const v = clamp(1 - e.offsetY / height, 0, 1);

--- a/src/colorpicker.ts
+++ b/src/colorpicker.ts
@@ -1,75 +1,70 @@
 import { clamp, HSV, toHSV, toRGB } from "./util.ts";
 
-export const initColorPicker = (dom: HTMLElement) => {
-  const $palette = dom.querySelector<HTMLElement>(".palette");
-  const $thumb = dom.querySelector<HTMLElement>(".thumb");
-  const $hue = dom.querySelector<HTMLInputElement>(`input[name="hue"]`);
-  const $saturation = dom.querySelector<HTMLOutputElement>(
-    `[name="saturation"]`,
-  );
-  const $brightness = dom.querySelector<HTMLOutputElement>(
-    `[name="brightness"]`,
-  );
-  if (!$palette || !$thumb || !$hue || !$saturation || !$brightness) {
-    throw new Error("dom is not ColorPicker");
+declare const $colorpicker: HTMLFieldSetElement;
+declare const $colorpallet: HTMLDivElement;
+declare const $colorSV: HTMLDivElement;
+declare const $colorH: HTMLInputElement;
+
+let target: HTMLInputElement;
+const state: HSV = { h: 138, s: 0.5, v: 1 };
+export const setPicker = ($input?: HTMLInputElement) => {
+  if ($input) target = $input;
+  setHSV(toHSV(target.value));
+  target?.insertAdjacentElement("afterend", $colorpicker);
+};
+const setHSV = ({ h, s, v }: Partial<HSV>, needsRGB = false) => {
+  if (h != void 0 && h != state.h) {
+    state.h = h;
+    $colorH.valueAsNumber = h;
+    $colorpicker.style.setProperty("--picked-hue", h.toString());
+    needsRGB = true;
   }
-
-  let target: HTMLInputElement;
-  const state: HSV = { h: 138, s: 0.5, v: 1 };
-  const setTarget = ($input: HTMLInputElement) => {
-    target = $input;
-    setHSV(toHSV(target.value));
-  };
-  const setHSV = ({ h, s, v }: Partial<HSV>, needsRGB = false) => {
-    if (h != void 0 && h != state.h) {
-      state.h = h;
-      $hue.valueAsNumber = h;
-      dom.style.setProperty("--picked-hue", "" + h);
-      needsRGB = true;
-    }
-    if (s != void 0 && s != state.s) {
-      state.s = s;
-      $thumb.style.setProperty("left", `${100 * s}%`);
-      needsRGB = true;
-    }
-    if (v != void 0 && v != state.v) {
-      state.v = v;
-      $thumb.style.setProperty("top", `${100 - 100 * v}%`);
-      needsRGB = true;
-    }
-    if (target && needsRGB) {
-      target.value = toRGB(...Object.values(state));
-      target.dispatchEvent(
-        new InputEvent("input", { bubbles: true, cancelable: true }),
-      );
-    }
-  };
-  const { width: paletteWidth, height: paletteHeight } = $palette
-    .getBoundingClientRect();
-  $hue.oninput = () => {
-    setHSV({ h: $hue.valueAsNumber });
-  };
-  const handlePointerMove = (e: PointerEvent) => {
-    if (e.buttons == 1) {
-      $palette.setPointerCapture(e.pointerId);
-      const top = clamp(e.offsetY, 0, paletteHeight);
-      const left = clamp(e.offsetX, 0, paletteWidth);
-      setHSV({ s: left / paletteWidth, v: 1 - top / paletteHeight });
-      // $thumb.style.setProperty("top", top + "px");
-      // $thumb.style.setProperty("left", left + "px");
-      // saturation = ;
-      // brightness = 1 - top / paletteHeight;
-    }
-  };
-  $palette.onpointermove = handlePointerMove;
-  $palette.onpointerdown = handlePointerMove;
-
-  document.querySelectorAll<HTMLInputElement>(`input[type="color"]`)
-    .forEach(($input) =>
-      $input.addEventListener("click", (e) => {
-        if ($input.disabled || !$input.name) return;
-        e.preventDefault();
-        setTarget($input);
-      })
+  if (s != void 0 && s != state.s) {
+    state.s = s;
+    $colorSV.style.setProperty("left", `${100 * s}%`);
+    needsRGB = true;
+  }
+  if (v != void 0 && v != state.v) {
+    state.v = v;
+    $colorSV.style.setProperty("top", `${100 - 100 * v}%`);
+    needsRGB = true;
+  }
+  if (target && needsRGB) {
+    target.value = toRGB(...Object.values(state));
+    target.dispatchEvent(
+      new InputEvent("input", { bubbles: true, cancelable: true }),
     );
+  }
+};
+const handlePointerMove = (e: PointerEvent) => {
+  if (e.buttons == 1) {
+    $colorpallet.setPointerCapture(e.pointerId);
+    const { width, height } = $colorpallet.getBoundingClientRect();
+    const v = clamp(1 - e.offsetY / height, 0, 1);
+    const s = clamp(e.offsetX / width, 0, 1);
+    setHSV({ s, v });
+  }
+};
+
+export const initColorPicker = (
+  inputs: HTMLInputElement[],
+  { initTarget = inputs.at(-1) } = {},
+) => {
+  $colorH.oninput = () => {
+    setHSV({ h: $colorH.valueAsNumber });
+  };
+  $colorpallet.onpointermove = handlePointerMove;
+  $colorpallet.onpointerdown = handlePointerMove;
+
+  inputs.forEach(($input) => {
+    $input.addEventListener("click", (e) => {
+      if ($input == target || $input.disabled || !$input.name) return;
+      e.preventDefault();
+      setPicker($input);
+    });
+    $input.addEventListener("input", () => {
+      if ($input == target) setHSV(toHSV(target.value));
+    });
+  });
+  setPicker(initTarget);
 };

--- a/src/colorpicker.ts
+++ b/src/colorpicker.ts
@@ -1,0 +1,75 @@
+import { clamp, HSV, toHSV, toRGB } from "./util.ts";
+
+export const initColorPicker = (dom: HTMLElement) => {
+  const $palette = dom.querySelector<HTMLElement>(".palette");
+  const $thumb = dom.querySelector<HTMLElement>(".thumb");
+  const $hue = dom.querySelector<HTMLInputElement>(`input[name="hue"]`);
+  const $saturation = dom.querySelector<HTMLOutputElement>(
+    `[name="saturation"]`,
+  );
+  const $brightness = dom.querySelector<HTMLOutputElement>(
+    `[name="brightness"]`,
+  );
+  if (!$palette || !$thumb || !$hue || !$saturation || !$brightness) {
+    throw new Error("dom is not ColorPicker");
+  }
+
+  let target: HTMLInputElement;
+  const state: HSV = { h: 138, s: 0.5, v: 1 };
+  const setTarget = ($input: HTMLInputElement) => {
+    target = $input;
+    setHSV(toHSV(target.value));
+  };
+  const setHSV = ({ h, s, v }: Partial<HSV>, needsRGB = false) => {
+    if (h != void 0 && h != state.h) {
+      state.h = h;
+      $hue.valueAsNumber = h;
+      dom.style.setProperty("--picked-hue", "" + h);
+      needsRGB = true;
+    }
+    if (s != void 0 && s != state.s) {
+      state.s = s;
+      $thumb.style.setProperty("left", `${100 * s}%`);
+      needsRGB = true;
+    }
+    if (v != void 0 && v != state.v) {
+      state.v = v;
+      $thumb.style.setProperty("top", `${100 - 100 * v}%`);
+      needsRGB = true;
+    }
+    if (target && needsRGB) {
+      target.value = toRGB(...Object.values(state));
+      target.dispatchEvent(
+        new InputEvent("input", { bubbles: true, cancelable: true }),
+      );
+    }
+  };
+  const { width: paletteWidth, height: paletteHeight } = $palette
+    .getBoundingClientRect();
+  $hue.oninput = () => {
+    setHSV({ h: $hue.valueAsNumber });
+  };
+  const handlePointerMove = (e: PointerEvent) => {
+    if (e.buttons == 1) {
+      $palette.setPointerCapture(e.pointerId);
+      const top = clamp(e.offsetY, 0, paletteHeight);
+      const left = clamp(e.offsetX, 0, paletteWidth);
+      setHSV({ s: left / paletteWidth, v: 1 - top / paletteHeight });
+      // $thumb.style.setProperty("top", top + "px");
+      // $thumb.style.setProperty("left", left + "px");
+      // saturation = ;
+      // brightness = 1 - top / paletteHeight;
+    }
+  };
+  $palette.onpointermove = handlePointerMove;
+  $palette.onpointerdown = handlePointerMove;
+
+  document.querySelectorAll<HTMLInputElement>(`input[type="color"]`)
+    .forEach(($input) =>
+      $input.addEventListener("click", (e) => {
+        if ($input.disabled || !$input.name) return;
+        e.preventDefault();
+        setTarget($input);
+      })
+    );
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,7 @@ $reset.onclick = (e) => {
 };
 
 $random.onclick = () => {
-  $color.hugecolor.value = toRGB(Math.random() * 360);
+  $color.hugecolor.value = toRGB({ h: Math.random() * 360, s: .5, v: 1 });
   setColor();
   setPicker();
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,13 @@
-import { getStyleString, getViewboxString, Huge, throttle } from "./util.ts";
+import {
+  getStyleString,
+  getViewboxString,
+  Huge,
+  throttle,
+  toRGB,
+} from "./util.ts";
 import { orbio } from "./orbio.ts";
 import { puge } from "./puge.ts";
+import { initColorPicker } from "./colorpicker.ts";
 
 declare const $huge: HTMLFormElement;
 declare const $parts: HTMLFormElement;
@@ -50,19 +57,6 @@ $reset.onclick = (e) => {
   setColor();
 };
 
-const clamp = (n: number, min: number, max: number) =>
-  Math.min(max, Math.max(min, n));
-const toRGB = (h = 138, s = 0.5, v = 1) => {
-  h = (h < 0 ? h % 360 + 360 : h) % 360 / 60;
-  s = s < 0 ? 0 : s > 1 ? 1 : s;
-  v = v < 0 ? 0 : v > 1 ? 1 : v;
-  const [r, g, b] = [5, 3, 1].map((n) =>
-    Math.round(
-      (v - clamp(2 - Math.abs(2 - (h + n) % 6), 0, 1) * s * v) * 255,
-    )
-  );
-  return `#${(r << 16 | g << 8 | b).toString(16).padStart(6, "0")}`;
-};
 $random.onclick = () => {
   $color.hugecolor.value = toRGB(Math.random() * 360);
   setColor();
@@ -130,3 +124,4 @@ $output.onsubmit = () => {
 setHuge();
 setViewbox();
 setSVG();
+initColorPicker($colorpicker);

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import {
 } from "./util.ts";
 import { orbio } from "./orbio.ts";
 import { puge } from "./puge.ts";
-import { initColorPicker } from "./colorpicker.ts";
+import { initColorPicker, setPicker } from "./colorpicker.ts";
 
 declare const $huge: HTMLFormElement;
 declare const $parts: HTMLFormElement;
@@ -55,11 +55,13 @@ $reset.onclick = (e) => {
   e.preventDefault();
   $color.reset();
   setColor();
+  setPicker();
 };
 
 $random.onclick = () => {
   $color.hugecolor.value = toRGB(Math.random() * 360);
   setColor();
+  setPicker();
 };
 
 const setViewbox = throttle(() => {
@@ -124,4 +126,7 @@ $output.onsubmit = () => {
 setHuge();
 setViewbox();
 setSVG();
-initColorPicker($colorpicker);
+const $colorInputs = [...$color.elements].filter(isInput).filter((el) =>
+  el.type === "color"
+);
+initColorPicker($colorInputs);

--- a/src/util.ts
+++ b/src/util.ts
@@ -46,9 +46,9 @@ export function getViewboxString(formdata: FormData, { svgSize = 512 } = {}) {
   const y = Math.round(cy - w / 2);
   return [x, y, w, w].join(" ");
 }
-export const clamp = (n: number, min: number, max: number) =>
+export const clamp = (n: number, min = 0, max = 1) =>
   Math.min(max, Math.max(min, n));
-export const toRGB = (h = 138, s = 0.5, v = 1) => {
+export const toRGB = ({ h = 360, s = 0.5, v = 1 }: Partial<HSV> = {}) => {
   h = (h < 0 ? h % 360 + 360 : h) % 360 / 60;
   s = clamp(s, 0, 1);
   v = clamp(v, 0, 1);
@@ -64,7 +64,7 @@ export interface HSV {
   s: number;
   v: number;
 }
-export const toHSV = (rgb = "#80ffa6"): HSV => {
+export const toHSV = (rgb: string = "#ff8080"): HSV => {
   const rgbNum = parseInt(rgb.replaceAll(/[^a-f\d]/ig, ""), 16),
     [r, g, b] = [16, 8, 0].map((n) => rgbNum >> n & 0xff),
     max = Math.max(r, g, b),

--- a/src/util.ts
+++ b/src/util.ts
@@ -46,3 +46,33 @@ export function getViewboxString(formdata: FormData, { svgSize = 512 } = {}) {
   const y = Math.round(cy - w / 2);
   return [x, y, w, w].join(" ");
 }
+export const clamp = (n: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, n));
+export const toRGB = (h = 138, s = 0.5, v = 1) => {
+  h = (h < 0 ? h % 360 + 360 : h) % 360 / 60;
+  s = clamp(s, 0, 1);
+  v = clamp(v, 0, 1);
+  const [r, g, b] = [5, 3, 1].map((n) =>
+    Math.round(
+      (v - clamp(2 - Math.abs(2 - (h + n) % 6), 0, 1) * s * v) * 255,
+    )
+  );
+  return `#${(r << 16 | g << 8 | b).toString(16).padStart(6, "0")}`;
+};
+export interface HSV {
+  h: number;
+  s: number;
+  v: number;
+}
+export const toHSV = (rgb = "#80ffa6"): HSV => {
+  const rgbNum = parseInt(rgb.replaceAll(/[^a-f\d]/ig, ""), 16),
+    [r, g, b] = [16, 8, 0].map((n) => rgbNum >> n & 0xff),
+    max = Math.max(r, g, b),
+    diff = max - Math.min(r, g, b),
+    i = [r, g, b].indexOf(max),
+    [a1, a2] = [r, g, b, r, g].slice(i + 1),
+    v = max / 255,
+    s = max ? diff / max : 0,
+    h = s ? ((a1 - a2) / diff * 60 + 120 * i + 360) % 360 : 0;
+  return { h, s, v };
+};


### PR DESCRIPTION
Androidでの色入力動作の改善のために、HSVで入力できるカラーピッカーを実装した
- カラーピッカーのターゲットでないinput[type="color"]をタップすると、直後の位置にカラーピッカーを移動しターゲットとする
- カラーピッカーのターゲットであるinput[type="color"]を再度タップすると、ブラウザの基本動作の色入力がトリガーする
- 別の方法でターゲットであるinput[type="color"]にinputが発生すると、カラーピッカーを更新する

resolves #2 